### PR TITLE
daemonise worker threads so tests can be terminated with TERM signal

### DIFF
--- a/bin/testcode.py
+++ b/bin/testcode.py
@@ -334,11 +334,15 @@ run_test_args: arguments to pass to test.run_test method.
                                 )
                     for test in serialized_tests]
         for job in jobs:
-            job.daemon = True  # daemonise so thread terminates when master dies
+            # daemonise so thread terminates when master dies
+            try:
+                job.setDaemon(True)  # first, try the old API
+            except AttributeError:
+                job.daemon = True  
             job.start()
 
         # We avoid .join() which is blocking making it unresponsive to TERM
-        while threading.activeCount > 0:
+        while threading.active_count() > 1:
             time.sleep(0.5)
     else:
         # run straight through, one at a time


### PR DESCRIPTION
testcode currently does not terminate on TERM signal. This makes it difficult to stop when run from the command line, and makes running concurrent tests from a CI system (e.g. buildbot) problematic.

The suggested changes daemonises the threads and removes the blocking `.join()` call on the master so it can attend to signals. 

A ctrl-c should now  terminate the master and all worker threads, albeit quite abruptly which may sometimes result in a traceback from depending on the progress of the thread.
