### PR TITLE
print out data_table when verbose==2 and results are not comparable

### DIFF
--- a/lib/testcode2/__init__.py
+++ b/lib/testcode2/__init__.py
@@ -394,7 +394,7 @@ first, during initialisation.'''
                                                           verbose)
                 (comparable, status, msg) = validation.compare_data(bench_out,
                         test_out, self.default_tolerance, self.tolerances)
-                if verbose > 2:
+                if verbose > 2 or (verbose == 2 and not comparable):
                     # Include data tables in output.
                     if comparable:
                         # Combine test and benchmark dictionaries.


### PR DESCRIPTION
The output for a `-v` run (`verbose==2`) is fantastic for my current use case (I'm configuring a buildbot setup for CASTEP). The output is not flooded with information and only the relevant discrepancies are printed. 

However, in the case where data is not comparable the string _"Different sets of data extracted from benchmark and test."_ is output with no additional details. Since the user has no direct access to the builds and cannot do a _compare_ run, it won't be easy for them to determine what went wrong.

This pull request attempts to address this by printing out the data tables when `verbose==2` and `comparable == False`.
