### PR TITLE
Compatibility fix for python 2.6

### DIFF
--- a/lib/testcode2/__init__.py
+++ b/lib/testcode2/__init__.py
@@ -106,6 +106,7 @@ class TestProgram:
             elif self.extract_program:
                 warnings.warn('importlib not available.  Will attempt to '
                               'analyse data via an external script.')
+                self.extract_fn = None
             else:
                 raise exceptions.TestCodeError('importlib not available and '
                               'no data extraction program supplied.')


### PR DESCRIPTION
If extract_fn is set when using python <= 2.6, although a
warning is printed, the data extraction still attempts to
use it, giving an exception.  Unset it in this case to
avoid the problem.
